### PR TITLE
Add utils for model loading and weight management; integrate with dis…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ROADMAP.md
 scripts
 
 __pycache__/
+services/models/**/weights/

--- a/services/models/distilbert/main.py
+++ b/services/models/distilbert/main.py
@@ -1,10 +1,75 @@
-from fastapi import FastAPI
 import os
+import logging
+from typing import Tuple, Any
+from fastapi import FastAPI
+from schemas import PredictRequest, PredictResponse
+import sys
+from pathlib import Path
+_CURRENT_DIR = Path(__file__).parent
+_PARENT_DIR = _CURRENT_DIR.parent
+if str(_PARENT_DIR) not in sys.path:
+    sys.path.insert(0, str(_PARENT_DIR))
 
 app = FastAPI()
 
 MODEL_ID = os.getenv("MODEL_ID", "distilbert-base-uncased-finetuned-sst-2-english")
 
+sentiment_pipeline = None
+model_ready = False
+
+
+def load_model(model_id: str) -> Tuple[Any, Any]:
+    from utils import load_model as load_generic_model
+    from transformers import (
+        AutoConfig,
+        AutoTokenizer,
+        AutoModelForSequenceClassification,
+    )
+    service_logger = logging.getLogger("models.distilbert")
+
+    model, tokenizer = load_generic_model(
+        model_id,
+        model_from_pretrained=AutoModelForSequenceClassification.from_pretrained,
+        config_from_pretrained=AutoConfig.from_pretrained,
+        model_from_config=AutoModelForSequenceClassification.from_config,
+        processor_from_pretrained=AutoTokenizer.from_pretrained,
+        weights_dir=os.path.join(_CURRENT_DIR, "weights"),
+        logger=service_logger,
+    )
+    return model, tokenizer
+
+
+@app.on_event("startup")
+async def startup_event():
+    global sentiment_pipeline, model_ready
+    from transformers import pipeline  # Lazy import
+
+    # Configure per-service logger
+    service_logger = logging.getLogger("models.distilbert")
+    if not service_logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter("%(levelname)s - %(name)s - %(message)s")
+        handler.setFormatter(formatter)
+        service_logger.addHandler(handler)
+    service_logger.setLevel(logging.INFO)
+
+    model, tokenizer = load_model(MODEL_ID)
+    sentiment_pipeline = pipeline("sentiment-analysis", model=model, tokenizer=tokenizer)
+    _ = sentiment_pipeline("Hello world!")
+    model_ready = True
+
 @app.get("/health")
 async def health():
-    return {"status": "ok", "modelReady": True}
+    return {"status": "ok", "modelReady": model_ready}
+
+
+@app.post("/predict", response_model=PredictResponse)
+async def predict(request: PredictRequest):
+    result = sentiment_pipeline(request.text)[0]
+    # Map HF output to our schema
+    return {
+        "label": result["label"].lower(),
+        "score": float(result["score"]),
+        "modelId": MODEL_ID,
+    }

--- a/services/models/distilbert/pyproject.toml
+++ b/services/models/distilbert/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastapi>=0.116.1",
     "torch>=2.8.0",
     "transformers>=4.56.1",
+    "uvicorn>=0.35.0",
 ]
 
 [[tool.uv.index]]

--- a/services/models/distilbert/schemas.py
+++ b/services/models/distilbert/schemas.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, Field
+
+class PredictRequest(BaseModel):
+    """Payload used to predict sentiment of a text."""
+    text: str = Field(min_length=1, max_length=512, description="Text to predict sentiment of")
+
+class PredictResponse(BaseModel):
+    """Response from the model."""
+    label: str = Field(description="Sentiment of the text")
+    score: float = Field(description="Score of the sentiment")
+    modelId: str = Field(min_length=1, description="Identifier of the model")

--- a/services/models/distilbert/uv.lock
+++ b/services/models/distilbert/uv.lock
@@ -108,6 +108,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -125,6 +137,7 @@ dependencies = [
     { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "transformers" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -132,6 +145,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "torch", specifier = ">=2.8.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transformers", specifier = ">=4.56.1" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
 [[package]]
@@ -176,6 +190,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -953,4 +976,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
 ]

--- a/services/models/utils.py
+++ b/services/models/utils.py
@@ -1,0 +1,90 @@
+import os
+import re
+import logging
+from typing import Any, Callable, Optional, Tuple
+
+
+def _sanitize_model_id(model_id: str) -> str:
+    """Sanitize model_id for filesystem safety."""
+    return re.sub(r"[^a-zA-Z0-9._-]+", "_", model_id)
+
+
+def _default_weights_dir() -> str:
+    """Return default weights directory path (sibling to this file)."""
+    service_dir = os.path.dirname(__file__)
+    weights_dir = os.path.join(service_dir, "weights")
+    os.makedirs(weights_dir, exist_ok=True)
+    return weights_dir
+
+
+def _weights_path(model_id: str, weights_dir: Optional[str] = None, suffix: str = ".pt") -> str:
+    safe_model_id = _sanitize_model_id(model_id)
+    base_dir = weights_dir or _default_weights_dir()
+    os.makedirs(base_dir, exist_ok=True)
+    return os.path.join(base_dir, f"{safe_model_id}{suffix}")
+
+
+def load_model(
+    model_id: str,
+    *,
+    model_from_pretrained: Callable[[str], Any],
+    config_from_pretrained: Optional[Callable[[str], Any]] = None,
+    model_from_config: Optional[Callable[[Any], Any]] = None,
+    processor_from_pretrained: Optional[Callable[[str], Any]] = None,
+    weights_dir: Optional[str] = None,
+    save_weights: bool = True,
+    logger: Optional[logging.Logger] = None,
+    logger_name: Optional[str] = None,
+) -> Tuple[Any, Optional[Any]]:
+    """
+    Load a Transformers model with local weight caching.
+
+    - If a local state_dict exists in weights/{model_id}.pt, instantiate via config and load state.
+    - Otherwise, download via model_from_pretrained(model_id) and save state_dict.
+    - Optionally also return a processor (tokenizer/processor/image processor) if provided.
+
+    This is generic for text, vision, and multimodal models as long as you pass
+    the appropriate constructors for the desired model type.
+
+    Args:
+        model_id: The identifier of the model to load.
+        model_from_pretrained: A function that loads a model from pretrained.
+        config_from_pretrained: A function that loads a config from pretrained.
+        model_from_config: A function that loads a model from a config.
+        processor_from_pretrained: A function that loads a processor from pretrained.
+        weights_dir: The directory to save the weights to.
+        save_weights: Whether to save the weights to the weights_dir.
+
+    Returns:
+        A tuple containing the model and the processor.
+    """
+    import torch
+    if logger is None:
+        logger = logging.getLogger(logger_name) if logger_name else logging.getLogger(__name__)
+
+    weights_path = _weights_path(model_id, weights_dir)
+
+    if os.path.exists(weights_path) and config_from_pretrained and model_from_config:
+        config = config_from_pretrained(model_id)
+        model = model_from_config(config)
+        state_dict = torch.load(weights_path, map_location="cpu")
+        model.load_state_dict(state_dict)
+        logger.info("Model '%s' loaded from local weights: %s", model_id, weights_path)
+    else:
+        model = model_from_pretrained(model_id)
+        if save_weights:
+            try:
+                torch.save(model.state_dict(), weights_path)
+                logger.info(
+                    "Model '%s' downloaded and weights saved to: %s", model_id, weights_path
+                )
+            except Exception:
+                # Best-effort save; continue even if saving fails, include traceback
+                logger.warning(
+                    "Model '%s' downloaded but failed to save weights to: %s", model_id, weights_path, exc_info=True
+                )
+        else:
+            logger.info("Model '%s' downloaded (weights not saved)", model_id)
+
+    processor = processor_from_pretrained(model_id) if processor_from_pretrained else None
+    return model, processor


### PR DESCRIPTION
Add utils for model loading and weight management; integrate with distilbert service

- Introduced a new utility module for sanitizing model IDs, managing weight directories, and loading models with local weight caching.
- Updated the distilbert service to utilize the new model loading utility, enhancing the model initialization process.
- Added Pydantic schemas for request and response handling in the prediction endpoint.
- Included uvicorn as a dependency for running the FastAPI application.
- Added a pre-trained model weight file for sentiment analysis.